### PR TITLE
Fix failing tests with aws-amplify mock

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,20 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Mock aws-amplify to prevent loading real library in tests
+jest.mock('aws-amplify', () => ({
+  Amplify: { configure: jest.fn() },
+  Auth: {
+    currentAuthenticatedUser: jest.fn().mockRejectedValue(new Error('Not authenticated')),
+    federatedSignIn: jest.fn(),
+  },
+}));
+
+import Login from './components/auth/Login';
+
+test('renders login button', async () => {
+  render(<Login />);
+  // Wait for authentication check to finish
+  const button = await screen.findByRole('button', { name: /sign in with google/i });
+  expect(button).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update tests to mock `aws-amplify`
- wait for login button before asserting

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684a1f702d44832eb256b334aab10f4f